### PR TITLE
Fix SQL query error when threads contain no posts

### DIFF
--- a/library/bdReputation/Model/Given.php
+++ b/library/bdReputation/Model/Given.php
@@ -268,7 +268,9 @@ class bdReputation_Model_Given extends XenForo_Model {
 			if (!isset($conditions[$intField])) continue;
 			
 			if (is_array($conditions[$intField])) {
-				if (!empty($conditions[$intField])) {
+				if (count($conditions[$intField]) == 0) {
+					$sqlConditions[] = "1 = 0";
+				} else {
 					$sqlConditions[] = "given.$intField IN (" . $db->quote($conditions[$intField]) . ")";
 				}
 			} else {


### PR DESCRIPTION
Hello xfrocks,

As promised, here is the pull request.

"1 = 0" may look weird but it was the most correct way to fix it with as few line edits as possible.
